### PR TITLE
Fix #657 - Missing proxy for onSelectAll trigger

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -192,6 +192,7 @@
 
         this.options.multiple = this.$select.attr('multiple') === "multiple";
         this.options.onChange = $.proxy(this.options.onChange, this);
+        this.options.onSelectAll = $.proxy(this.options.onSelectAll, this);
         this.options.onDropdownShow = $.proxy(this.options.onDropdownShow, this);
         this.options.onDropdownHide = $.proxy(this.options.onDropdownHide, this);
         this.options.onDropdownShown = $.proxy(this.options.onDropdownShown, this);


### PR DESCRIPTION
No proxy was defined for the onSelectAll trigger. This resulted in an inconsistent behaviour with other triggers such as onChange, where "this" is defined as the Multiselect object. This has now been fixed.
